### PR TITLE
Ipv4 and Ipv6 support, C++ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
-UDP Logging for esp32
-=====================
+# UDP Logging for esp32
 
-How To
-------
+## How To
 
 Just include the component into your project, include the header file and call udp_logging_init()
 
     #include "udp_logging.h"
-    
-    udp_logging_init( CONFIG_LOG_UDP_IP, CONFIG_LOG_UDP_PORT, udp_logging_vprintf );
+
+    udp_logging_init( "myserver", "3333", udp_logging_vprintf );
 
 On the server execute the logging_server.py file using Python v3:
 
     $ python3 logging_server.py
 
-
-
-License
--------
+## License
 
 This code is licensed under the Apache License v2.0

--- a/include/udp_logging.h
+++ b/include/udp_logging.h
@@ -26,7 +26,7 @@ extern "C" {
 #include <string.h>
 extern int udp_log_fd;
 
-int udp_logging_init(const char *ipaddr, unsigned long port, vprintf_like_t func);
+int udp_logging_init(const char *node, const char *service, vprintf_like_t func);
 int udp_logging_vprintf( const char *str, va_list l );
 void udp_logging_free(va_list l);
 

--- a/library.json
+++ b/library.json
@@ -1,0 +1,4 @@
+{
+  "name": "embedded-esp32-component-udp_logging",
+  "version": "0.0.0+20250731140158"
+}

--- a/udp_logging.c
+++ b/udp_logging.c
@@ -35,9 +35,10 @@ int get_socket_error_code(int socket)
 {
 	int result;
 	u32_t optlen = sizeof(int);
-	if(getsockopt(socket, SOL_SOCKET, SO_ERROR, &result, &optlen) == -1) {
-	printf("getsockopt failed");
-	return -1;
+	if (getsockopt(socket, SOL_SOCKET, SO_ERROR, &result, &optlen) == -1)
+	{
+		printf("getsockopt failed");
+		return -1;
 	}
 	return result;
 }
@@ -49,33 +50,39 @@ int show_socket_error_reason(int socket)
 	return err;
 }
 
-void udp_logging_free(va_list l) {
-	int err = 0;
-	char *err_buf;
-    esp_log_set_vprintf(vprintf);
-    if( (err = shutdown(udp_log_fd, 2)) == 0 )
+void udp_logging_free(va_list l)
+{
+	if (udp_log_fd != 0)
 	{
-		vprintf("\nUDP socket shutdown!", l);
-	}else
-	{
-    	asprintf(&err_buf, "\nShutting-down UDP socket failed: %d!\n", err);
-		vprintf(err_buf, l);
-	}
+		int err = 0;
+		char *err_buf;
+		esp_log_set_vprintf(vprintf);
+		if ((err = shutdown(udp_log_fd, 2)) == 0)
+		{
+			vprintf("\nUDP socket shutdown!", l);
+		}
+		else
+		{
+			asprintf(&err_buf, "\nShutting-down UDP socket failed: %d!\n", err);
+			vprintf(err_buf, l);
+		}
 
-    if( (err = close( udp_log_fd )) == 0 )
-    {
-		vprintf("\nUDP socket closed!", l);
-	}else
-	{
-		asprintf(&err_buf, "\n Closing UDP socket failed: %d!\n", err);
-		vprintf(err_buf, l);
+		if ((err = close(udp_log_fd)) == 0)
+		{
+			vprintf("\nUDP socket closed!", l);
+		}
+		else
+		{
+			asprintf(&err_buf, "\n Closing UDP socket failed: %d!\n", err);
+			vprintf(err_buf, l);
+		}
+		udp_log_fd = 0;
 	}
-    udp_log_fd = 0;
 }
 
-
-int udp_logging_vprintf( const char *str, va_list l ) {
-    int err = 0;
+int udp_logging_vprintf(const char *str, va_list l)
+{
+	int err = 0;
 	int len;
 	char task_name[16];
 	char *cur_task = pcTaskGetName(xTaskGetCurrentTaskHandle());
@@ -83,8 +90,8 @@ int udp_logging_vprintf( const char *str, va_list l ) {
 	task_name[15] = 0;
 	if (strncmp(task_name, "tiT", 16) != 0)
 	{
-		len = vsprintf((char*)buf, str, l);
-		if( (err = sendto(udp_log_fd, buf, len, 0, (struct sockaddr *)&serveraddr, sizeof(serveraddr))) < 0 )
+		len = vsprintf((char *)buf, str, l);
+		if ((err = sendto(udp_log_fd, buf, len, 0, (struct sockaddr *)&serveraddr, sizeof(serveraddr))) < 0)
 		{
 			show_socket_error_reason(udp_log_fd);
 			vprintf("\nFreeing UDP Logging. sendto failed!\n", l);
@@ -92,7 +99,7 @@ int udp_logging_vprintf( const char *str, va_list l ) {
 			return vprintf("UDP Logging freed!\n\n", l);
 		}
 	}
-	return vprintf( str, l );
+	return vprintf(str, l);
 }
 
 int udp_logging_init(const char *node, const char *service, vprintf_like_t func)
@@ -122,14 +129,13 @@ int udp_logging_init(const char *node, const char *service, vprintf_like_t func)
 
 	ESP_LOGI(TAG, "Logging to %s", node);
 
-    int err = setsockopt(udp_log_fd, SOL_SOCKET, SO_SNDTIMEO, (const char *)&send_timeout, sizeof(send_timeout));
-	if (err < 0) {
-	   ESP_LOGE("UDP_LOGGING", "Failed to set SO_SNDTIMEO. Error %d", err);
+	int err = setsockopt(udp_log_fd, SOL_SOCKET, SO_SNDTIMEO, (const char *)&send_timeout, sizeof(send_timeout));
+	if (err < 0)
+	{
+		ESP_LOGE("UDP_LOGGING", "Failed to set SO_SNDTIMEO. Error %d", err);
 	}
 
-    esp_log_set_vprintf(func);
+	esp_log_set_vprintf(func);
 
-    return 0;
+	return 0;
 }
-
-


### PR DESCRIPTION
Now udp_logging:init accepts hostname in addition to IP addresses.

Depreceated  Methods replaced:
- use of pcTaskGetName instead of pcTaskGetTaskName
- use of getaddrinfo instead of inet_aton

Fixed C++ compiler warnings

closes #7